### PR TITLE
Reset error state on TransformableImage

### DIFF
--- a/src/libraries/TransformableImage/index.js
+++ b/src/libraries/TransformableImage/index.js
@@ -60,7 +60,7 @@ export default class TransformableImage extends PureComponent {
     componentWillReceiveProps (nextProps) {
         if (!sameImage(this.props.image, nextProps.image)) {
             // image source changed, clear last image's imageDimensions info if any
-            this.setState({ imageDimensions: nextProps.image.dimensions, keyAcumulator: this.state.keyAcumulator + 1 });
+            this.setState({ imageDimensions: nextProps.image.dimensions, keyAcumulator: this.state.keyAcumulator + 1, error: false });
             if (!nextProps.image.dimensions) { // if we don't have image dimensions provided in source
                 this.getImageSize(nextProps.image);
             }


### PR DESCRIPTION
### The issue this PR fixes

`TransformableImage` cannot display image with updated source when the _previous source_ had thrown an error.

### Solution

Reset the `error` state of the `TransformableImage` when its source gets updated. 