### PR TITLE
Add support for getting image's size when the source contains headers

### DIFF
--- a/src/libraries/TransformableImage/index.js
+++ b/src/libraries/TransformableImage/index.js
@@ -104,8 +104,16 @@ export default class TransformableImage extends PureComponent {
         }
 
         if (source && source.uri) {
-            Image.getSize(
-                source.uri,
+            let getSize;
+            let params = [source.uri];
+            if (source.headers && Image.getSizeWithHeaders) {
+                params.push(source.headers);
+                getSize = Image.getSizeWithHeaders;
+            } else {
+                getSize = Image.getSize;
+            }
+            getSize(
+                ...params,
                 (width, height) => {
                     if (width && height) {
                         if (this.state.imageDimensions && this.state.imageDimensions.width === width && this.state.imageDimensions.height === height) {


### PR DESCRIPTION

#### Summary

Adds support for getting an image's size even when the image source contains headers.